### PR TITLE
missing 's' added to url to make it plural

### DIFF
--- a/junction/client.py
+++ b/junction/client.py
@@ -15,7 +15,7 @@ URI_PARTS = {'conference': 'api/v1/conferences/',
              'room': 'api/v1/rooms/?venue={}',
              'schedule': 'api/v1/schedules/?conference={}',
              'device': 'api/v1/devices/',
-             'feedback': 'api/v1/feedback/',
+             'feedback': 'api/v1/feedbacks/',
              'feedback_questions': 'api/v1/feedback_questions/?conference_id={}'}  # noqa
 
 


### PR DESCRIPTION
restful URL with plural name
